### PR TITLE
Allow BP engine to use modern JS language features

### DIFF
--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
@@ -206,7 +206,9 @@ public abstract class BProgram {
      */
     protected Object evaluate(String script, String scriptName) {
         try {
-            return Context.getCurrentContext().evaluateString(programScope, script, scriptName, 1, null);
+            Context curCtx = Context.getCurrentContext();
+            curCtx.setLanguageVersion(Context.VERSION_1_8);
+            return curCtx.evaluateString(programScope, script, scriptName, 1, null);
         } catch (EcmaError rerr) {
             if ( rerr.getErrorMessage().trim().equals("\"bsync\" is not defined.") ) {
                 throw new BPjsCodeEvaluationException("'bsync' is only defined in BThreads. Did you forget to call 'bp.registerBThread()'?", rerr);


### PR DESCRIPTION
Update our usage of Rhino to use modern language features such as let expressions and generators.