### PR TITLE
Change DEFAULT_PRIORITY of Prioritized event selection strategies 

### DIFF
--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/internal/ScriptableUtils.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/internal/ScriptableUtils.java
@@ -241,31 +241,30 @@ public class ScriptableUtils {
     }
     
     /**
-     * A problematic-yet-working way of getting a meanningful toString 
+     * A problematic-yet-working way of getting a meaningful toString
      * on a NativeSet.
      * @param ns
      * @return a textual description of {@code ns}.
      */
     private static String toString(NativeSet ns) {
-        
+
         String code = "const arr=[]; ns.forEach(e=>arr.push(e)); arr";
-        
+
          try {
             Context curCtx = Context.enter();
             curCtx.setLanguageVersion(Context.VERSION_ES6);
-            ImporterTopLevel importer = new ImporterTopLevel(curCtx);
-            Scriptable tlScope = curCtx.initStandardObjects(importer);
+            ImporterTopLevel tlScope = new ImporterTopLevel(curCtx);
             tlScope.put("ns", tlScope, ns);
             Object resultObj = curCtx.evaluateString(
-                tlScope, code, 
+                tlScope, code,
                 "", 1, null);
-            
+
             NativeArray arr = (NativeArray) resultObj;
             return arr.getIndexIds().stream().map( id -> stringify(arr.get(id), true) ).collect(joining(", "));
-            
+
         } finally {
             Context.exit();
         }
-        
+
     }
 }

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/model/eventselection/PrioritizedBSyncEventSelectionStrategy.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/model/eventselection/PrioritizedBSyncEventSelectionStrategy.java
@@ -50,6 +50,8 @@ import org.mozilla.javascript.Context;
  */
 public class PrioritizedBSyncEventSelectionStrategy extends AbstractEventSelectionStrategy {
 
+    public static final int DEFAULT_PRIORITY = 0;
+
     public PrioritizedBSyncEventSelectionStrategy(long seed) {
         super(seed);
     }
@@ -94,7 +96,7 @@ public class PrioritizedBSyncEventSelectionStrategy extends AbstractEventSelecti
     
     private int getValue( SyncStatement stmt ) {
         return (stmt.hasData() && (stmt.getData() instanceof Number))? 
-                ((Number)stmt.getData()).intValue() : Integer.MIN_VALUE;
+                ((Number)stmt.getData()).intValue() : DEFAULT_PRIORITY;
     }
 
     

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/model/eventselection/PrioritizedBThreadsEventSelectionStrategy.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/model/eventselection/PrioritizedBThreadsEventSelectionStrategy.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  */
 public class PrioritizedBThreadsEventSelectionStrategy extends AbstractEventSelectionStrategy {
 
-    public static final int DEFAULT_PRIORITY = -1;
+    public static final int DEFAULT_PRIORITY = 0;
     
     /** A mapping of b-thread names to their priorities. */
     final private Map<String, Integer> priorities = new HashMap<>();


### PR DESCRIPTION
Change the DEFAULT_PRIORITY of PrioritizedBThreadsEventSelectionStrategy to 0 (a neutral number is more natural for non prioritized b-threads).

Change the DEFAULT_PRIORITY of PrioritizedBSyncEventSelectionStrategy to 0 (instead of Integer.MIN_VALUE).
