### PR TITLE
BUG FIX in ScriptableUtils.toString(NativeSet ns)

### DIFF
--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/internal/ScriptableUtils.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/internal/ScriptableUtils.java
@@ -241,7 +241,7 @@ public class ScriptableUtils {
     }
     
     /**
-     * A problematic-yet-working way of getting a meanningful toString 
+     * A problematic-yet-working way of getting a meaningful toString
      * on a NativeSet.
      * @param ns
      * @return a textual description of {@code ns}.
@@ -253,8 +253,7 @@ public class ScriptableUtils {
          try {
             Context curCtx = Context.enter();
             curCtx.setLanguageVersion(Context.VERSION_ES6);
-            ImporterTopLevel importer = new ImporterTopLevel(curCtx);
-            Scriptable tlScope = curCtx.initStandardObjects(importer);
+            ImporterTopLevel tlScope = new ImporterTopLevel(curCtx);
             tlScope.put("ns", tlScope, ns);
             Object resultObj = curCtx.evaluateString(
                 tlScope, code, 


### PR DESCRIPTION
BUG FIX: ImporterTopLevel c'tor already calls initStandardObjects with "this" therefore the call is redundant. In some cases it even triggers an exception, when it reaches the line in NativeGlobal: ScriptableObject.defineProperty(scope, "NaN", ScriptRuntime.NaNobj, 7);