### PR TITLE
addSync Outside of BThread Exception

### DIFF
--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/exceptions/BPjsSyncOutsideBThreadException.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/exceptions/BPjsSyncOutsideBThreadException.java
@@ -1,0 +1,17 @@
+package il.ac.bgu.cs.bp.bpjs.exceptions;
+
+/**
+ * Thrown when a sync statement is called outside of a BThread.
+ *
+ * @author maor
+ */
+public class BPjsSyncOutsideBThreadException extends BPjsRuntimeException{
+
+    public BPjsSyncOutsideBThreadException(String message) {
+        super(message);
+    }
+
+    public BPjsSyncOutsideBThreadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/execution/jsproxy/BProgramJsProxy.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/execution/jsproxy/BProgramJsProxy.java
@@ -1,6 +1,7 @@
 package il.ac.bgu.cs.bp.bpjs.execution.jsproxy;
 
 import il.ac.bgu.cs.bp.bpjs.exceptions.BPjsRuntimeException;
+import il.ac.bgu.cs.bp.bpjs.exceptions.BPjsSyncOutsideBThreadException;
 import il.ac.bgu.cs.bp.bpjs.execution.tasks.FailedAssertionException;
 import il.ac.bgu.cs.bp.bpjs.internal.ScriptableUtils;
 import il.ac.bgu.cs.bp.bpjs.model.*;
@@ -237,7 +238,7 @@ public class BProgramJsProxy extends SyncStatementBuilder
     protected void synchronizationPoint(NativeObject jsRWB, Boolean hot, Object data) {
         
         if ( CURRENT_BTHREAD.get() == null ) {
-            throw new BPjsRuntimeException("Calling bp.sync outside of a b-thread is forbidden");
+            throw new BPjsSyncOutsideBThreadException("Calling bp.sync outside of a b-thread is forbidden");
         }
         
         Map<String, Object> jRWB = (Map) Context.jsToJava(jsRWB, Map.class);


### PR DESCRIPTION
add BPjsSyncOutsideBThreadException class, and throw it when calling sync out of bthread instead of BPjsRunTimeException