### PR TITLE
fix: wrap bp.log methods to add dummy param and lazy stringify (#241)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is BPjs
+
+BPjs is a Java framework for executing and verifying **Behavioral Programs (BP)** — concurrent JavaScript programs (b-threads) that synchronize at `bp.sync()` points via events. The core model: each b-thread declares what events it *requests*, *waits for*, *blocks*, and what should *interrupt* it. An event selection strategy resolves these declarations to choose which event fires next.
+
+The framework supports two operating modes: **execution** (run one trace) and **verification** (DFS over all possible traces to find violations).
+
+## Build & Test Commands
+
+```bash
+# Build
+mvn clean package
+
+# Run all tests
+mvn test
+
+# Run a specific test class
+mvn test -Dtest=GeneralTest
+
+# Run a specific test method
+mvn test -Dtest=GeneralTest#someMethodName
+
+# Build standalone uber-jar
+mvn clean package -P uber-jar
+
+# Generate coverage report (output: target/coverage-reports/index.html)
+mvn clean test jacoco:report
+```
+
+Test framework: JUnit 4 with Hamcrest. Tests live under `src/test/java` and corresponding JS fixtures under `src/test/resources`.
+
+## Architecture
+
+### Core Loop: Execution
+
+`BProgramRunner` drives the execution cycle:
+1. All registered b-threads reach `bp.sync()` — each submits a `SyncStatement`
+2. `EventSelectionStrategy` picks one selectable event (requested but not blocked)
+3. The chosen event is fired: waiting b-threads are resumed, interrupted b-threads are killed
+4. Repeat until no b-threads remain or no event can be selected
+
+### Core Loop: Analysis/Veification
+
+`DfsBProgramVerifier` explores all program traces by cloning `BProgramSyncSnapshot` at each state and performing a DFS over he BProgram's state space.
+`VisitedStateStore` implementations (snapshot-level or b-thread-level) detect visited nodes on that state space, and prevent the DFS from getting top an infinite loops when traversing cycles.
+`ExecutionTraceInspection` objects define what constitutes a violation (e.g., `HOT_SYSTEM`, `HOT_BTHREADS`, assertion failures).
+
+### Key Classes by Package
+
+| Package | Key Classes | Purpose |
+|---|---|---|
+| `model` | `BProgram`, `BEvent`, `SyncStatement`, `BProgramSyncSnapshot`, `BThreadSyncSnapshot` | Core domain model |
+| `model.eventselection` | `EventSelectionStrategy` + implementations | How events are chosen at each sync point |
+| `model.eventsets` | `EventSet`, `JsEventSet`, `ComposableEventSet` | Representations of event collections |
+| `execution` | `BProgramRunner` | Runs one BProgram trace |
+| `execution.jsproxy` | `BProgramJsProxy` | The `bp` object available in JavaScript; bridges JS ↔ Java |
+| `execution.tasks` | `StartBThread`, `ResumeBThread`, `StartFork` | Runnable units for the thread pool |
+| `analysis` | `DfsBProgramVerifier`, `ExecutionTrace`, `VisitedStateStore`, `VerificationResult` | Model checking via DFS |
+| `analysis.violations` | `Violation`, `FailedAssertionViolation`, `JsErrorViolation` | Violation types |
+| `bprogramio` | `BProgramSyncSnapshotCloner`, serialization stubs | State cloning/serialization for verification |
+| `bprogramio.log` | `BpLog`, `PrintStreamBpLog`, `BpListLog` | Logging infrastructure |
+| `exceptions` | `BPjsRuntimeException`, `BPjsCodeEvaluationException`, etc. | Typed exceptions |
+| `internal` | `ScriptableUtils`, `BPjsRhinoContextFactory`, `ExecutorServiceMaker` | Low-level Rhino and threading utilities |
+| `mains` | `BPjsCliRunner` | CLI entry point (`--verify`, `--max-trace-length`, `--liveness`) |
+| (root) | `BPjs` | Global singleton: Rhino context factory, executor service, stubber registry, global logger |
+
+### JavaScript ↔ Java Bridge
+
+The Rhino JavaScript engine (v1.9.1, supports arrow functions in b-threads) runs user scripts. `BProgramJsProxy` is exposed as `bp` inside JS. It translates `bp.sync(...)`, `bp.log(...)`, `bp.fork(...)`, `bp.registerBThread(...)` into Java operations. Type conversions and scope management go through `ScriptableUtils` and `BPjsRhinoContextFactory`.
+
+
+### Pluggability
+
+- **Event selection**: implement `EventSelectionStrategy` (or use decorator classes `LoggingEventSelectionStrategyDecorator`, `PausingEventSelectionStrategyDecorator`)
+- **Serialization**: register custom `SerializationStubber` via `BPjs.addSerializationStubberFactory()`
+- **Verification inspections**: compose `ExecutionTraceInspection` objects
+
+## JavaScript Global Scope
+
+`src/main/resources/globalScopeInit.js` bootstraps the JS environment loaded into every BProgram. Changes here affect all b-thread scripts.
+
+## Java Version & Dependencies
+
+- Java 11 (source and target)
+- Rhino 1.9.1 (Mozilla JS engine)
+- JUnit 4.13.2 / Hamcrest 2.2 (test)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ If you use BPjs in an academic work, please consider citing it as:
 
 ## Change Log for the BPjs Library.
 
+### 2026-04
+
+* :tada: Loggers correctly distinguish between printing and array and printing a message with array of argument ([#241](https://github.com/bThink-BGU/BPjs/issues/241) (thanks @Codergoterrors)
+* :sparkles: Added methods for checking loggin level from JS: `bp.log.isLevelEnabled(levelName)`
+* :sparkles: Refactored the logging mechanism tom make new loggers easier.
+* :arrow_up: `bp.log.setLevel` is more lenient about level names (e.g. users can use `Info` and `info` which would both yield `LogLevel.Info`.
+* :sparkles: Added CLAUDE.md.
+
 ### 2026-03
 
 * :arrow_up: Upgraded to Rhino 1.9.1. Now supporting modern JS structures, such as arrow functions for bthreads ([#240](https://github.com/bThink-BGU/BPjs/issues/240)).

--- a/docs/source/BPjsTutorial/logging.rst
+++ b/docs/source/BPjsTutorial/logging.rst
@@ -56,28 +56,6 @@ The BPjs logger formats messages using Java's `MessageFormat`_. Under the hood, 
   [BP][Info] 3.142 3.14 3.1416
 
 
-Caution - Array Ambiguity
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A curious API edge-case occurs when using message formatting, and passing a single variable for printing, AND said single variable is an array. The system auto-spreads the array, and only the first item of the array is printed. So the following code:
-
-.. code::
-
-  bp.registerBThread("t1",function(){
-    bp.log.info("array:{0}", ["x","y","z"]);
-  });
-
-Prints this::
-
-[BP][Info] array:x 
-
-To work around this, either include a dummy variable, or wrap the array in another array::
-
-  bp.log.info("array:{0}", [["x","y","z"]]);
-  bp.log.info("array:{0}", ["x","y","z"], "dummy val");
-
-
-
 
 .. _logback: https://logback.qos.ch
 .. _log4j2: http://logging.apache.org/log4j/2.x/index.html

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/AbstractBpLog.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/AbstractBpLog.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 michael.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package il.ac.bgu.cs.bp.bpjs.bprogramio.log;
+
+/**
+ * Base class for loggers, containing convenience methods.
+ * 
+ * @author michael
+ */
+public abstract class AbstractBpLog implements BpLog {
+    
+    
+    protected LogLevel level = DEFAULT_LOG_LEVEL;
+    
+    @Override
+    public void warn(Object aMessage, Object... someArgs) {
+        log(LogLevel.Warn, aMessage, someArgs);
+    }
+
+    @Override
+    public void info(Object aMessage, Object... someArgs) {
+        log(LogLevel.Info, aMessage, someArgs);
+    }
+
+    @Override
+    public void fine(Object aMessage, Object... someArgs) {
+        log(LogLevel.Fine, aMessage, someArgs);
+    }
+
+    @Override
+    public void error(Object aMessage, Object... someArgs) {
+        log(LogLevel.Error, aMessage, someArgs);
+    }
+    
+    @Override
+    public void log(LogLevel aLevel, Object aMessage, Object[] someArgs) {
+        if (level.compareTo(aLevel) >= 0) {
+            doLog(aLevel, aMessage, someArgs);
+        }
+    }
+    
+    @Override
+    public boolean isLevelEnabled(String levelName) {
+        LogLevel aLevel = LogLevel.lenientValueOf(levelName.trim());
+        return (level.compareTo(aLevel) >= 0);
+    }
+    
+    @Override
+    public void setLevel(String levelName) {
+        synchronized (this) {
+            try {
+                level = LogLevel.lenientValueOf(levelName.trim());
+            } catch (IllegalArgumentException iae) {
+                error("Unknown log level: '{0}'", levelName);
+            }
+        }
+    }
+
+    @Override
+    public String getLevel() {
+        return getTypedLevel().name();
+    }
+
+    public LogLevel getTypedLevel() {
+        return level;
+    }
+    
+    public void setTypedLevel( LogLevel aLevel ) {
+        level = (aLevel!=null ? aLevel : LogLevel.Info);
+    }
+    
+    /**
+     * Actual logging happens here. No need to filter by log level etc.
+     * 
+     * @param aLevel
+     * @param aMessage
+     * @param someArgs 
+     */
+    protected abstract void doLog(LogLevel aLevel, Object aMessage, Object[] someArgs);
+}

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpListLog.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpListLog.java
@@ -10,9 +10,7 @@ import java.util.List;
  *
  * @author michael
  */
-public class BpListLog implements BpLog {
-
-    private String level = "info";
+public class BpListLog extends AbstractBpLog {
 
     private final List<String> all   = new LinkedList<>();
     private final List<String> warn  = new LinkedList<>();
@@ -20,29 +18,11 @@ public class BpListLog implements BpLog {
     private final List<String> fine  = new LinkedList<>();
     private final List<String> off   = new LinkedList<>();
     private final List<String> error = new LinkedList<>();
+    
+    private PrintStream outStrm = null;
 
     @Override
-    public void warn(Object msg, Object... args) {
-        log(LogLevel.Warn, msg, args);
-    }
-
-    @Override
-    public void info(Object msg, Object... args) {
-        log(LogLevel.Info, msg, args);
-    }
-
-    @Override
-    public void fine(Object msg, Object... args) {
-        log(LogLevel.Fine, msg, args);
-    }
-
-    @Override
-    public void error(Object msg, Object... args) {
-        log(LogLevel.Error, msg, args);
-    }
-
-    @Override
-    public void log(LogLevel lvl, Object msg, Object[] args) {
+    public void doLog(LogLevel lvl, Object msg, Object[] args) {
         String message = formatMessage(lvl, msg, args);
         all.add(message);
         switch (lvl) {
@@ -63,20 +43,14 @@ public class BpListLog implements BpLog {
                 off.add(message);
                 break;
         }
+        if ( outStrm != null ) {
+            outStrm.println(message);
+        }
     }
-
+    
     @Override
-    public void setLevel(String levelName) {
-        level = levelName;
-    }
-
-    @Override
-    public String getLevel() {
-        return level;
-    }
-
-    @Override
-    public void setLoggerPrintStream(PrintStream printStream) {
+    public void setLoggerPrintStream(PrintStream aPrintStream) {
+        outStrm = aPrintStream;
     }
 
     public List<String> getWarn() {

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpLog.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpLog.java
@@ -27,7 +27,10 @@ package il.ac.bgu.cs.bp.bpjs.bprogramio.log;
 import il.ac.bgu.cs.bp.bpjs.internal.ScriptableUtils;
 import java.io.PrintStream;
 import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Set;
 
 /**
@@ -51,19 +54,35 @@ public interface BpLog extends java.io.Serializable {
     void setLevel(String levelName);
 
     String getLevel();
-
+    
+    boolean isLevelEnabled(String levelName);
+    
     void setLoggerPrintStream(PrintStream printStream);
 
     public enum LogLevel {
-        Off, Error, Warn, Info, Fine
+        Off, Error, Warn, Info, Fine;
+        
+        public static LogLevel lenientValueOf(String levelName) {
+            if ( levelName == null ) return LogLevel.Info;
+            if ( levelName.equals("") ) return LogLevel.Info;
+            
+            String lcLevelName = levelName.trim().toLowerCase();
+            for( LogLevel l : LogLevel.values() ){
+                if (l.toString().toLowerCase().equals(lcLevelName) ) {
+                    return l;
+                }
+            }
+            
+            throw new IllegalArgumentException("Unknown log level: '" + levelName + "'");
+        }
     }
     
     /**
      * A set of classes that can use their own {@code toString()} method. Classes 
      * not in this set are formatted using custom formatting code.
      */
-    public static final Set<Class> PASS_THROUGH = Set.of(Integer.class, Long.class,
-        Short.class, Double.class, Float.class, String.class);
+    public static final Set<Class<?>> PASS_THROUGH = Set.of(Integer.class, Long.class,
+        Short.class, Double.class, Float.class, String.class, Date.class, LocalDate.class, LocalDateTime.class);
     
     /**
      * Default formatting of a log message. This method should not deal with 
@@ -76,19 +95,30 @@ public interface BpLog extends java.io.Serializable {
      * @see MessageFormat
      */
     default String formatMessage(LogLevel lvl, Object msg, Object[] args) {
-        return "[BP][" + lvl.name() + "] " +
-            (((args==null)||(args.length > 0))
-            ? MessageFormat.format( (msg!=null ? msg.toString():"<null>"), Arrays.stream(args).map(this::formatArg).toArray())
-            : ScriptableUtils.stringify(msg));
+        String prefix = "[BP][" + lvl.name() + "] ";
+        if ( msg == null ) return prefix + "<null>";
+        if ( args.length == 0 ) { 
+            return prefix + formatArg(msg);
+        }
+        try {
+            Object[] formattedArgs = Arrays.stream(args).map(this::formatArg).toArray();
+            return prefix + MessageFormat.format( formatArg(msg).toString(), formattedArgs );
+        } catch (Exception e) {
+            error( "Message formatting exception: " + e.getMessage() );
+            return prefix + msg;
+        }   
     }
     
     /**
-     * Formats a single logging message argument.
+     * Formats a single logging message argument. NOTE: for pass-through classes, 
+     * the formatted argument needs to maintain its class, so that the MessageFormat
+     * instructions can kick in.
+     * 
      * @param arg an object to format
      * @return a {@code toString()}-able view of {@code arg}.
      */
     default Object formatArg(Object arg) {
-        if ( arg == null ) return arg;
+        if ( arg == null ) return null;
         if ( PASS_THROUGH.contains(arg.getClass()) ) return arg;
         return ScriptableUtils.stringify(arg);
     }

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/PrintStreamBpLog.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/PrintStreamBpLog.java
@@ -32,9 +32,8 @@ import java.io.PrintWriter;
  *
  * @author maor
  */
-public class PrintStreamBpLog implements BpLog {
+public class PrintStreamBpLog extends AbstractBpLog {
 
-    LogLevel level = DEFAULT_LOG_LEVEL;
     private PrintWriter out = new PrintWriter(System.out);
     
     private boolean autoFlush = true;
@@ -50,60 +49,16 @@ public class PrintStreamBpLog implements BpLog {
     public PrintStreamBpLog() {
         this( System.out );
     }
-
-    @Override
-    public void warn(Object msg, Object... args) {
-        log(LogLevel.Warn, msg, args);
-    }
-
-    @Override
-    public void info(Object msg, Object... args) {
-        log(LogLevel.Info, msg, args);
-    }
-
-
-    @Override
-    public void fine(Object msg, Object... args) {
-        log(LogLevel.Fine, msg, args);
-    }
-
-    @Override
-    public void error(Object msg, Object... args) {
-        log(LogLevel.Error, msg, args);
-    }
-
-    @Override
-    public void log(LogLevel lvl, Object msg, Object[] args) {
-        if (level.compareTo(lvl) >= 0) {
-            synchronized (this) {
-                out.println(formatMessage(lvl, msg, args));
-                if ( autoFlush ) {
-                    flush();
-                }
-            }
-        }
-    }
-
-    @Override
-    public void setLevel(String levelName) {
-        synchronized (this) {
-            try {
-                level = LogLevel.valueOf(levelName.trim());
-            } catch (IllegalArgumentException iae) {
-                error("Unknown log level: '{0}'", levelName);
-            }
-        }
-    }
-
-    @Override
-    public String getLevel() {
-        return level.name();
-    }
-
-    public LogLevel getTypedLevel() {
-        return level;
-    }
     
+    @Override
+    protected void doLog(LogLevel lvl, Object msg, Object[] args) {
+        synchronized (this) {
+            out.println(formatMessage(lvl, msg, args));
+            if ( autoFlush ) {
+                flush();
+            }
+        }
+    }
 
     @Override
     public void setLoggerPrintStream(PrintStream printStream){

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/execution/jsproxy/BProgramJsProxy.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/execution/jsproxy/BProgramJsProxy.java
@@ -90,7 +90,38 @@ public class BProgramJsProxy extends SyncStatementBuilder
 
     private final AtomicInteger autoAddCounter = new AtomicInteger(0);
 
-    public final BpLog log;
+    private BpLog javaLog;
+    private Object jsLogOverride;
+
+    /**
+     * Returns the log object visible to JavaScript ({@code bp.log}). When JavaScript
+     * assigns a new value to {@code bp.log}, this returns that override. Java callers
+     * should use {@link #getJavaLog()} instead.
+     */
+    public Object getLog() {
+        return (jsLogOverride != null) ? jsLogOverride : javaLog;
+    }
+
+    /**
+     * Called by Rhino when JavaScript assigns to {@code bp.log}.
+     * Accepts either a {@link BpLog} (replaces the Java logger) or a JS wrapper object.
+     */
+    public void setLog(Object o) {
+        if (o instanceof BpLog) {
+            javaLog = (BpLog) o;
+            jsLogOverride = null;
+        } else {
+            jsLogOverride = o;
+        }
+    }
+
+    /**
+     * Returns the underlying Java {@link BpLog}. Use this from Java code rather
+     * than {@link #getLog()}, which may return a JavaScript wrapper object.
+     */
+    public BpLog getJavaLog() {
+        return javaLog;
+    }
 
     /**
      * Deprecated - use eventSets.all
@@ -114,12 +145,12 @@ public class BProgramJsProxy extends SyncStatementBuilder
 
     public BProgramJsProxy(BProgram aBProgram) {
         bProg = aBProgram;
-        this.log = new PrintStreamBpLog();
+        this.javaLog = new PrintStreamBpLog();
     }
 
     public BProgramJsProxy(BProgram aBProgram, BpLog log) {
         bProg = aBProgram;
-        this.log = log;
+        this.javaLog = log;
     }
 
     /**

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
@@ -288,6 +288,7 @@ public abstract class BProgram {
         FailedAssertionViolation failedAssertion = null;
         try (Context ctx = BPjs.enterRhinoContext()) {
             initProgramScope();
+            evaluate(BPjs.class.getResourceAsStream("/globalScopeInit.js"), "globalScopeInit.js", ctx);
 
             // evaluate code in order
             if (prependedCode != null) {

--- a/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
+++ b/src/main/java/il/ac/bgu/cs/bp/bpjs/model/BProgram.java
@@ -317,10 +317,10 @@ public abstract class BProgram {
                   new BProgramJsProxy(this)
                   : new BProgramJsProxy(this, preSetLogger);
         if ( preSetLogLevel != null ) {
-            jsProxy.log.setLevel(preSetLogLevel.name());
+            jsProxy.getJavaLog().setLevel(preSetLogLevel.name());
         }
         if ( preSetPrintStream != null ) {
-            jsProxy.log.setLoggerPrintStream(preSetPrintStream);
+            jsProxy.getJavaLog().setLoggerPrintStream(preSetPrintStream);
         }
 
         initialScopeValues.entrySet().forEach(e -> putInGlobalScope(e.getKey(), e.getValue()));
@@ -506,7 +506,7 @@ public abstract class BProgram {
      */
     public void setLogLevel( BpLog.LogLevel aLevel ) {
         if ( jsProxy != null ) {
-            jsProxy.log.setLevel(aLevel.name());
+            jsProxy.getJavaLog().setLevel(aLevel.name());
         } else {
             preSetLogLevel = aLevel;
         }
@@ -532,15 +532,15 @@ public abstract class BProgram {
      */
     public void setLoggerOutputStreamer(PrintStream printStream){
         if ( jsProxy != null ) {
-            jsProxy.log.setLoggerPrintStream(printStream);
+            jsProxy.getJavaLog().setLoggerPrintStream(printStream);
         } else {
             preSetPrintStream = printStream;
         }
     }
 
     public BpLog.LogLevel getLogLevel() {
-        return (jsProxy != null ) 
-            ? BpLog.LogLevel.valueOf(jsProxy.log.getLevel())
+        return (jsProxy != null )
+            ? BpLog.LogLevel.valueOf(jsProxy.getJavaLog().getLevel())
             : (preSetLogLevel!= null)? preSetLogLevel: BpLog.DEFAULT_LOG_LEVEL;
     }
     
@@ -549,7 +549,7 @@ public abstract class BProgram {
      * @return the b-program logger (or {@code null}).
      */
     public BpLog getLogger() {
-        return jsProxy != null ? jsProxy.log : null;
+        return jsProxy != null ? jsProxy.getJavaLog() : null;
     }
     
     public StorageModificationStrategy getStorageModificationStrategy() {

--- a/src/main/resources/globalScopeInit.js
+++ b/src/main/resources/globalScopeInit.js
@@ -1,9 +1,35 @@
-/* global package imports, variables, etc., bp */
+/* global bp */
+// Wrap bp.log methods to:
+// 1. Add a dummy {} at the end to prevent the single-array-param Java varargs issue
+// 2. JSON.stringify params lazily (only when the log level is active)
+(function() {
+    var _javaLog = bp.log;
 
-// /!\ Currently deactivated, as we have nothing to add here yet. Re-activate in BProgram's setup() method.
+    function _wrapArgs(args) {
+        var result = [args[0]];
+        for (var i = 1; i < args.length; i++) {
+            var p = args[i];
+            if (p !== null && p !== undefined && typeof p === 'object') {
+                try { p = JSON.stringify(p); } catch(e) {}
+            }
+            result.push(p);
+        }
+        result.push({});
+        return result;
+    }
 
-//importPackage(Packages.bp);
-//importPackage(Packages.bp.eventsets);
+    bp.log = {
+        setLevel:             function(lvl) { _javaLog.setLevel(lvl); },
+        setLoggerPrintStream: function(ps)  { _javaLog.setLoggerPrintStream(ps); },
+        getLevel:             function()    { return _javaLog.getLevel(); },
+        isFineEnabled:        function()    { return _javaLog.isFineEnabled(); },
+        isInfoEnabled:        function()    { return _javaLog.isInfoEnabled(); },
+        isWarnEnabled:        function()    { return _javaLog.isWarnEnabled(); },
+        isErrorEnabled:       function()    { return _javaLog.isErrorEnabled(); },
 
-//importPackage(Packages.bp.exceptions);
-
+        fine:  function() { if (_javaLog.isFineEnabled())  _javaLog.fine.apply( _javaLog, _wrapArgs(arguments)); },
+        info:  function() { if (_javaLog.isInfoEnabled())  _javaLog.info.apply( _javaLog, _wrapArgs(arguments)); },
+        warn:  function() { if (_javaLog.isWarnEnabled())  _javaLog.warn.apply( _javaLog, _wrapArgs(arguments)); },
+        error: function() { if (_javaLog.isErrorEnabled()) _javaLog.error.apply(_javaLog, _wrapArgs(arguments)); }
+    };
+})();

--- a/src/main/resources/globalScopeInit.js
+++ b/src/main/resources/globalScopeInit.js
@@ -1,35 +1,35 @@
 /* global bp */
-// Wrap bp.log methods to:
-// 1. Add a dummy {} at the end to prevent the single-array-param Java varargs issue
-// 2. JSON.stringify params lazily (only when the log level is active)
+
+// Wrap bp.log to:
+// 1. Fix the single-array-param Java varargs issue: when the sole argument is an
+//    object/array, stringify it in JS before passing to Java so Rhino never has a
+//    chance to spread it across varargs parameters.
+// 2. Evaluate arguments lazily (only when the log level is active).
 (function() {
     var _javaLog = bp.log;
 
-    function _wrapArgs(args) {
-        var result = [args[0]];
-        for (var i = 1; i < args.length; i++) {
-            var p = args[i];
-            if (p !== null && p !== undefined && typeof p === 'object') {
-                try { p = JSON.stringify(p); } catch(e) {}
+    function _mkLogFn(levelName) {
+        return function() {
+            if (!_javaLog.isLevelEnabled(levelName)) return;
+            if ( arguments.length === 0 ) {
+                _javaLog[levelName.toLowerCase()](""); // edge case - user called logging with no arguments.
+                
+            } else {
+                let params = Array.from(arguments);
+                let msg = params.shift();
+                _javaLog[levelName.toLowerCase()](msg, params);
             }
-            result.push(p);
-        }
-        result.push({});
-        return result;
+        };
     }
 
     bp.log = {
         setLevel:             function(lvl) { _javaLog.setLevel(lvl); },
-        setLoggerPrintStream: function(ps)  { _javaLog.setLoggerPrintStream(ps); },
         getLevel:             function()    { return _javaLog.getLevel(); },
-        isFineEnabled:        function()    { return _javaLog.isFineEnabled(); },
-        isInfoEnabled:        function()    { return _javaLog.isInfoEnabled(); },
-        isWarnEnabled:        function()    { return _javaLog.isWarnEnabled(); },
-        isErrorEnabled:       function()    { return _javaLog.isErrorEnabled(); },
+        isLevelEnabled:       function(lvl) { return _javaLog.isLevelEnabled(lvl); },
 
-        fine:  function() { if (_javaLog.isFineEnabled())  _javaLog.fine.apply( _javaLog, _wrapArgs(arguments)); },
-        info:  function() { if (_javaLog.isInfoEnabled())  _javaLog.info.apply( _javaLog, _wrapArgs(arguments)); },
-        warn:  function() { if (_javaLog.isWarnEnabled())  _javaLog.warn.apply( _javaLog, _wrapArgs(arguments)); },
-        error: function() { if (_javaLog.isErrorEnabled()) _javaLog.error.apply(_javaLog, _wrapArgs(arguments)); }
+        fine:  _mkLogFn("Fine"),
+        info:  _mkLogFn("Info"),
+        warn:  _mkLogFn("Warn"),
+        error: _mkLogFn("Error")
     };
 })();

--- a/src/test/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpLogTest.java
+++ b/src/test/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/BpLogTest.java
@@ -1,0 +1,33 @@
+package il.ac.bgu.cs.bp.bpjs.bprogramio.log;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author michael
+ */
+public class BpLogTest {
+    
+    public BpLogTest() {
+    }
+
+    @Test
+    public void testLenientValueOfOk() {
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf(null));
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf(""));
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf("INFO"));
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf("Info"));
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf("info"));
+        assertEquals(BpLog.LogLevel.Info, BpLog.LogLevel.lenientValueOf(" info "));
+        assertEquals(BpLog.LogLevel.Error, BpLog.LogLevel.lenientValueOf("error"));
+        assertEquals(BpLog.LogLevel.Fine, BpLog.LogLevel.lenientValueOf("FINE"));
+        assertEquals(BpLog.LogLevel.Warn, BpLog.LogLevel.lenientValueOf("wArN"));
+        assertEquals(BpLog.LogLevel.Off, BpLog.LogLevel.lenientValueOf("off"));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testLenientValueOfBad() {
+        BpLog.LogLevel.lenientValueOf("this level does not exist");
+    }
+}

--- a/src/test/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/PrintStreamBpLogTest.java
+++ b/src/test/java/il/ac/bgu/cs/bp/bpjs/bprogramio/log/PrintStreamBpLogTest.java
@@ -1,4 +1,4 @@
-package il.ac.bgu.cs.bp.bpjs.bprogramio;
+package il.ac.bgu.cs.bp.bpjs.bprogramio.log;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;

--- a/src/test/java/il/ac/bgu/cs/bp/bpjs/execution/LoggingTest.java
+++ b/src/test/java/il/ac/bgu/cs/bp/bpjs/execution/LoggingTest.java
@@ -25,6 +25,7 @@ package il.ac.bgu.cs.bp.bpjs.execution;
 
 import il.ac.bgu.cs.bp.bpjs.bprogramio.log.BpListLog;
 import il.ac.bgu.cs.bp.bpjs.bprogramio.log.BpLog;
+import il.ac.bgu.cs.bp.bpjs.bprogramio.log.PrintStreamBpLog;
 import il.ac.bgu.cs.bp.bpjs.model.BProgram;
 import il.ac.bgu.cs.bp.bpjs.model.ResourceBProgram;
 import il.ac.bgu.cs.bp.bpjs.model.StringBProgram;
@@ -72,7 +73,7 @@ public class LoggingTest {
 
         var Log = new BpListLog();
         bprog.setLogger(Log);
-        new BProgramRunner( bprog).run();
+        new BProgramRunner(bprog).run();
 
         System.out.println("result:");
         System.out.println("off" + Log.getOff().toString());
@@ -82,10 +83,10 @@ public class LoggingTest {
         System.out.println("fine" + Log.getFine().toString());
 
         org.junit.Assert.assertEquals(0l, (long)Log.getOff().size());
-        org.junit.Assert.assertEquals(5l, (long)Log.getError().size());
-        org.junit.Assert.assertEquals(5l, (long)Log.getWarn().size());
-        org.junit.Assert.assertEquals(5l, (long)Log.getInfo().size());
-        org.junit.Assert.assertEquals(5l, (long)Log.getFine().size());
+        org.junit.Assert.assertEquals(4l, (long)Log.getError().size());
+        org.junit.Assert.assertEquals(3l, (long)Log.getWarn().size());
+        org.junit.Assert.assertEquals(2l, (long)Log.getInfo().size());
+        org.junit.Assert.assertEquals(1l, (long)Log.getFine().size());
     }
 
     @Test
@@ -167,24 +168,22 @@ public class LoggingTest {
     
     @Test
     public void testCompoundObjectLogging() throws IOException {
-        PrintStream originalOut = System.out;
         String result;
         
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             try (PrintStream myOut = new PrintStream(baos)) {
-                System.setOut(myOut);
-                
-                new BProgramRunner(new ResourceBProgram("logging/compound.js")).run();
+                final BProgramRunner runner = new BProgramRunner(new ResourceBProgram("logging/compound.js"));
+                BpLog logger = new PrintStreamBpLog(myOut);
+                runner.getBProgram().setLogger(logger);
+                runner.run();
                 myOut.flush();
-                
-            } finally {
-                System.setOut(originalOut);
             }
             result = baos.toString(StandardCharsets.UTF_8);    
         }
         
         System.out.println(result);
         
+        assertTrue(result.contains("3.142  3.14 42  3.1415900"));
         assertTrue(result.contains("Set"));
         assertTrue(result.contains("List"));
         assertTrue(result.contains("Map"));

--- a/src/test/resources/logging/compound.js
+++ b/src/test/resources/logging/compound.js
@@ -30,7 +30,17 @@ bp.log.info("Simple String");
 bp.log.info(1);
 bp.log.info(1.5);
 bp.log.info(["I'm","an","array"]);
+bp.log.info("{0}", ["I'm","an","array"]);
+bp.log.info("{0} {0}", ["I'm","an","array"]);
+bp.log.info(["Single emt arr"]);
+bp.log.info("Single emt");
+bp.log.info("array:{0}", ["x","y","z"]);
+bp.log.info(["just some args {0} {1}","arg1","arg2"]);
+bp.log.info("just some args {0} {1}","arg1","arg2");
 bp.log.info({im:"an", ob:"ject", arr:[1,2,"three"]});
+bp.log.info("Here is obj: {0} {1} {2}", {im:"an", ob:"ject", arr:[1,2,"three"]}, 2, 3);
+
+bp.log.info("{0} {0, number, #.##} {1} {0, number, 0.0000000}", 3.14159, 42);
 
 var set = new HashSet();
 set.add("a");

--- a/src/test/resources/logging/simple.js
+++ b/src/test/resources/logging/simple.js
@@ -24,7 +24,7 @@
  */
 
 
-var levels = ["Off", "Error", "Warn", "Info", "Fine"]
+const levels = ["Off", "Error", "Warn", "Info", "Fine"];
 
 for ( var i in levels ) {
     bp.log.setLevel(levels[i]);


### PR DESCRIPTION
Fixes #241

## Changes
- `globalScopeInit.js`: Added a JS-level wrapper around `bp.log` that:
  1. Always appends a dummy `{}` argument to every log call, preventing
     Java's varargs from misinterpreting a single array argument
  2. Lazily applies `JSON.stringify` to object params only when the
     log level means the message will actually be printed

- `BProgram.java`: Activated `globalScopeInit.js` by loading it during
  `setup()` right after `initProgramScope()`

## Testing
All 312 existing tests pass with 0 failures.